### PR TITLE
ci(DUV-9439): add PR validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,31 @@
+name: Validate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: actionlint
+        uses: raven-actions/actionlint@v2
+
+      - name: yamllint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: .
+          config_data: |
+            extends: default
+            rules:
+              line-length: {max: 200}
+              truthy: {check-keys: false}
+              document-start: disable
+              comments-indentation: disable
+              comments: disable

--- a/README.md
+++ b/README.md
@@ -1,8 +1,45 @@
 # github-actions
-Action templates for reuse on other repositories
 
-### Versioning
+Reusable composite GitHub Actions used by `mobileaction` service repos.
+
+## Available actions
+
+### Java (Gradle)
+
+| Action | Purpose |
+|---|---|
+| [`java/test`](java/test/action.yml) | Checkout, JDK setup, `./gradlew build`, upload test reports, optional Sentry release |
+| [`java/test_sonar`](java/test_sonar/action.yml) | Same as `java/test` plus SonarCloud analysis (`./gradlew build sonar`); requires `SONAR_TOKEN` |
+| [`java/coverage`](java/coverage/action.yml) | _Deprecated — no longer used_ |
+
+See [java/README.md](java/README.md) for usage examples.
+
+### Node (Yarn)
+
+| Action | Purpose |
+|---|---|
+| [`node/lint`](node/lint/action.yml) | `yarn install`, `yarn lint` (or any `yarn-command`) |
+| [`node/test`](node/test/action.yml) | `yarn install`, `yarn test` |
+| [`node/build`](node/build/action.yml) | `yarn install`, `yarn build` |
+
+## Usage
+
+Reference an action from any consumer repo, pinning to a major tag:
+
+```yaml
+- uses: mobileaction/github-actions/java/test_sonar@v5
 ```
-git tag -a -m "Description of this release" v1
+
+## Versioning
+
+```bash
+git tag -a -m "Description of this release" v6
 git push --follow-tags
 ```
+
+## CI
+
+Every PR is validated by [`.github/workflows/validate.yml`](.github/workflows/validate.yml):
+
+- **actionlint** — schema check + shellcheck on inline `shell: bash` steps.
+- **yamllint** — YAML format check across all `action.yml` files.

--- a/java/coverage/action.yml
+++ b/java/coverage/action.yml
@@ -2,5 +2,4 @@ name: 'MA Java CI Coverage'
 description: 'Coverage analysis flow, not used anymore'
 runs:
   using: "composite"
-  steps:
-
+  steps: []

--- a/java/test/action.yml
+++ b/java/test/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: true
     default: 'temurin'
   create-sentry-release:
-     description: 'Whether to create a Sentry release as part of this CI run.'
-     required: false
-     default: 'false'    
+    description: 'Whether to create a Sentry release as part of this CI run.'
+    required: false
+    default: 'false'
   sentry-environment:
     description: 'Sentry environment for the release (e.g., development, staging, production).'
     required: false

--- a/java/test_sonar/action.yml
+++ b/java/test_sonar/action.yml
@@ -15,21 +15,21 @@ runs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-        
+
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.java-distribution }}
         cache: gradle
-        
+
     - name: Cache SonarCloud packages
       uses: actions/cache@v5
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
-        
+
     - name: Build and analyze
       shell: bash
       run: ./gradlew build sonar --info


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/validate.yml` — runs on `pull_request` and `workflow_dispatch`.
  - **actionlint** validates workflow YAML schema and shellchecks inline `shell: bash` steps.
  - **yamllint** validates YAML format across the repo (including `action.yml` files — the actual deliverable of this repo).
- Fixes pre-existing yamllint errors so the new check passes from day one:
  - Trailing whitespace in `java/test/action.yml`, `java/test_sonar/action.yml`.
  - Wrong indentation under `create-sentry-release` in `java/test/action.yml`.
  - Empty `steps:` block in the unused `java/coverage/action.yml` → `steps: []`.

Functional smoke-tests (actually invoking each composite action against a sample project) are intentionally out of scope — they need fixtures and are a much larger change.

## Test plan
- [ ] CI's new `Validate / Lint` job is green on this PR.
- [ ] Future PRs that introduce trailing whitespace, bad indent, or an actionlint-flagged issue are blocked by the check.