### PR TITLE
docs(DUV-9439): add workflow + Gradle samples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,108 @@ Reference an action from any consumer repo, pinning to a major tag:
 - uses: mobileaction/github-actions/java/test_sonar@v5
 ```
 
+## Workflow samples
+
+Drop these files into `.github/workflows/` of a consumer repo. Adjust `java-version`, `sentry-project`, and branch names to match the target service. Secrets (`SONAR_TOKEN`, `SENTRY_AUTH_TOKEN`) must be configured in the repo's GitHub settings.
+
+### `sonarTest.yaml` — PR validation with SonarCloud
+
+Runs on every PR (except into `master`) and on pushes to `dev`. Executes `./gradlew build sonar` via [`java/test_sonar`](java/test_sonar/action.yml).
+
+```yaml
+name: 'Sonar Test'
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+        branches-ignore:
+            - master
+    push:
+        branches:
+            - dev
+
+env:
+    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+jobs:
+    build_test:
+        name: Build and Test
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: mobileaction/github-actions/java/test_sonar@v5
+              with:
+                java-version: 21
+```
+
+Also configure SonarCloud in `build.gradle`:
+
+```groovy
+plugins {
+    id "org.sonarqube" version "4.4.1.3373"
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "mobileaction_<service-name>"
+        property "sonar.organization", "mobileaction"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
+}
+```
+
+### `deployTest.yml` — production build + Sentry release
+
+Runs on push to `master` (post-merge, before Heroku deploys). Builds via [`java/test`](java/test/action.yml) and creates a Sentry release for the `production` environment.
+
+```yaml
+name: 'Deploy Test'
+on:
+  push:
+    branches:
+      - master
+
+env:
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  SENTRY_ORG: 'mobileaction'
+  SENTRY_PROJECT: '<service-name>'
+
+jobs:
+  build_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mobileaction/github-actions/java/test@v5
+        with:
+          java-version: 21
+          create-sentry-release: 'true'
+          sentry-environment: 'production'
+```
+
+Also configure the Sentry Gradle plugin in `build.gradle` so the CI build can upload source context and create the release:
+
+```groovy
+plugins {
+    id "io.sentry.jvm.gradle" version "6.1.0"
+}
+
+// Safely attempt to read the token from the environment
+def sentryToken = System.getenv("SENTRY_AUTH_TOKEN")
+
+sentry {
+    org = "mobileaction"
+    projectName = "<service-name>"
+
+    // Only enable the advanced Sentry features if the token actually exists
+    if (sentryToken != null && !sentryToken.trim().isEmpty()) {
+        authToken = sentryToken
+        includeSourceContext = true // Uploads inline code snippets in CI
+    } else {
+        includeSourceContext = false // Skips Sentry upload tasks for local developer builds
+    }
+}
+```
+
 ## Versioning
 
 ```bash


### PR DESCRIPTION
Include copy-paste sonarTest/deployTest workflow samples plus the matching SonarCloud and Sentry build.gradle snippets so consumer repos can adopt the shared composite actions without spelunking api-gateway.