### PR TITLE
docs(DUV-9439): SONAR_TOKEN is now an org secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Reference an action from any consumer repo, pinning to a major tag:
 
 Drop these files into `.github/workflows/` of a consumer repo. Adjust `java-version`, `sentry-project`, and branch names to match the target service.
 
-- `SENTRY_AUTH_TOKEN` is provided as an **organization secret** — it is inherited automatically, no per-repo setup needed.
-- `SONAR_TOKEN` must be configured **per repo** in the repo's GitHub Actions secrets — see [Creating your GitHub secrets](https://docs.sonarsource.com/sonarqube-server/10.5/devops-platform-integration/github-integration/adding-sonarqube-analysis-to-your-workflow#creating-your-github-secrets).
+`SENTRY_AUTH_TOKEN` and `SONAR_TOKEN` are provided as **organization secrets** — they are inherited automatically, no per-repo setup needed.
 
 ### `sonarTest.yaml` — PR validation with SonarCloud
 


### PR DESCRIPTION
SONAR_TOKEN has been moved to organization-level secrets, so consumer repos no longer need to configure it per-repo. Collapse the two secret bullets into a single sentence covering both shared tokens.